### PR TITLE
fixed create session error due to modelPathW for linux - minor changes

### DIFF
--- a/src/nn/onnx_model_base.cpp
+++ b/src/nn/onnx_model_base.cpp
@@ -56,8 +56,10 @@ OnnxModelBase::OnnxModelBase(const char* modelPath, const char* logid, const cha
     }
 
     std::cout << "Inference device: " << std::string(provider) << std::endl;
-    auto modelPathW = get_win_path(modelPath);
-    session = Ort::Session(env, modelPathW.c_str(), sessionOptions);
+    auto modelPathW = get_win_path(modelPath).c_str(); // For Windows (wstring)
+    // auto modelPathW = modelPath; // For Linux (string)
+    
+    session = Ort::Session(env, modelPathW, sessionOptions);
     //session = Ort::Session(env)
     // https://github.com/microsoft/onnxruntime/issues/14157
     //std::vector<const char*> inputNodeNames; //

--- a/src/nn/onnx_model_base.cpp
+++ b/src/nn/onnx_model_base.cpp
@@ -56,10 +56,12 @@ OnnxModelBase::OnnxModelBase(const char* modelPath, const char* logid, const cha
     }
 
     std::cout << "Inference device: " << std::string(provider) << std::endl;
-    auto modelPathW = get_win_path(modelPath).c_str(); // For Windows (wstring)
-    // auto modelPathW = modelPath; // For Linux (string)
-    
-    session = Ort::Session(env, modelPathW, sessionOptions);
+    #ifdef _WIN32
+        auto modelPathW = get_win_path(modelPath);  // For Windows (wstring)
+        session = Ort::Session(env, modelPathW.c_str(), sessionOptions);
+    #else
+        session = Ort::Session(env, modelPath, sessionOptions);  // For Linux (string)
+    #endif
     //session = Ort::Session(env)
     // https://github.com/microsoft/onnxruntime/issues/14157
     //std::vector<const char*> inputNodeNames; //


### PR DESCRIPTION
#### Issue
On Linux, while building it gave me this error due to `modelPathW` type.
```bash
yolov8-onnx-cpp/src/nn/onnx_model_base.cpp: In constructor ‘OnnxModelBase::OnnxModelBase(const char*, const char*, const char*)’:
yolov8-onnx-cpp/src/nn/onnx_model_base.cpp:62:67: error: no matching function for call to ‘Ort::Session::Session(Ort::Env&, const wchar_t*, Ort::SessionOptions&)’
   62 |     session = Ort::Session(env, modelPathW.c_str(), sessionOptions);
      |                                                                   ^
```
#### Correction 
Isolated the relevant line for Windows and Linus users so that they could comment it out as per their Operating System.
